### PR TITLE
Webfinger

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,5 +7,6 @@
     "johnpapa.vscode-peacock",
     "rubocop.vscode-rubocop",
     "bradlc.vscode-tailwindcss",
+    "github.vscode-github-actions",
   ]
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
-  allow_unauthenticated_access only: [ :show ]
+  allow_unauthenticated_access
+
   def index
     @users = User.order(:username)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,45 @@
+class UsersController < ApplicationController
+  allow_unauthenticated_access only: [ :show ]
+  def index
+    @users = User.order(:username)
+
+    respond_to do |format|
+      format.html { render :index }
+      format.json { render json: @users.map { |user| json_resource(user) }, status: :ok }
+    end
+  end
+
+  def show
+    @user = resource_user
+
+    if @user.blank?
+      render file: Rails.root.join("public/404.html"), status: :not_found, layout: false
+      return
+    end
+
+    respond_to do |format|
+      format.html { render :show }
+      format.json { render json: json_resource(@user), status: :ok }
+    end
+  end
+
+  private
+
+    def resource_user
+      return nil if resource_param.blank?
+      User.find_by(username: resource_param)
+    end
+
+    def resource_param
+      params.require(:username)
+    end
+
+    def json_resource(user)
+      return nil if user.blank?
+
+      {
+        username: user.username,
+        created_at: user.created_at
+      }
+    end
+end

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -1,0 +1,69 @@
+class WellKnown::WebfingerController < ApplicationController
+  allow_unauthenticated_access
+
+  # Example response from https://datatracker.ietf.org/doc/html/rfc7033#section-4.3
+  # GET /.well-known/webfinger?
+  #     resource=acct%3Abob%40example.com&
+  #     rel=http%3A%2F%2Fwebfinger.example%2Frel%2Fprofile-page&
+  #     rel=http%3A%2F%2Fwebfinger.example%2Frel%2Fbusinesscard
+  #
+  #  HTTP/1.1 200 OK
+  #  Access-Control-Allow-Origin: *
+  #  Content-Type: application/jrd+json
+  #
+  #  {
+  #    "subject" : "acct:bob@example.com",
+  #    "aliases" :
+  #    [
+  #      "https://www.example.com/~bob/"
+  #    ],
+  #    "properties" :
+  #    {
+  #        "http://example.com/ns/role" : "employee"
+  #    },
+  #    "links" :
+  #    [
+  #      {
+  #        "rel" : "http://webfinger.example/rel/profile-page",
+  #        "href" : "https://www.example.com/~bob/"
+  #      },
+  #      {
+  #        "rel" : "http://webfinger.example/rel/businesscard",
+  #        "href" : "https://www.example.com/~bob/bob.vcf"
+  #      }
+  #    ]
+  #  }
+
+  def show
+    if resource_user.blank?
+      render json: { error: "User not found" }, status: :not_found
+      return
+    end
+
+    result = {
+      subject: resource_param,
+      properties: {
+        "http://example.com/ns/role" => "author"
+      },
+      links: [
+        { rel: "http://webfinger.example/rel/profile-page", href: "TODO" },
+        { rel: "http://webfinger.example/rel/businesscard", href: "TODO" }
+      ]
+    }
+
+    expires_in 3.days, public: true
+    render json: result, status: :ok, content_type: "application/jrd+json"
+  end
+
+  private
+
+    def resource_user
+      return nil if resource_param.blank?
+      email_address = resource_param.sub("acct:", "")
+      User.find_by(email_address: email_address)
+    end
+
+    def resource_param
+      params.require(:resource)
+    end
+end

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -46,7 +46,7 @@ class WellKnown::WebfingerController < ApplicationController
       #   "https://example.com/ns/role" => "author"
       # },
       links: [
-        { rel: "self", type: "application/activity+json", href: root_url }
+        { rel: "self", type: "application/activity+json", href: user_url(resource_user.username) }
       ]
     }
 

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -46,8 +46,7 @@ class WellKnown::WebfingerController < ApplicationController
         "http://example.com/ns/role" => "author"
       },
       links: [
-        { rel: "http://webfinger.example/rel/profile-page", href: "TODO" },
-        { rel: "http://webfinger.example/rel/businesscard", href: "TODO" }
+        { rel: "self", type: "application/activity+json", href: root_url }
       ]
     }
 

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -42,9 +42,9 @@ class WellKnown::WebfingerController < ApplicationController
 
     result = {
       subject: resource_param,
-      properties: {
-        "http://example.com/ns/role" => "author"
-      },
+      # properties: {
+      #   "https://example.com/ns/role" => "author"
+      # },
       links: [
         { rel: "self", type: "application/activity+json", href: root_url }
       ]
@@ -58,8 +58,8 @@ class WellKnown::WebfingerController < ApplicationController
 
     def resource_user
       return nil if resource_param.blank?
-      email_address = resource_param.sub("acct:", "")
-      User.find_by(email_address: email_address)
+      username = resource_param.sub("acct:", "")
+      User.find_by(username: username)
     end
 
     def resource_param

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/helpers/well_known/webfinger_helper.rb
+++ b/app/helpers/well_known/webfinger_helper.rb
@@ -1,0 +1,2 @@
+module WellKnown::WebfingerHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,8 @@ class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
 
+  validates :email_address, presence: true, uniqueness: true
+  validates :username, presence: true, uniqueness: true
+
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,19 @@
+<div>
+  <h1 class="font-bold text-4xl">Users</h1>
+  <table class="min-w-full mt-4 border">
+    <thead>
+      <tr>
+        <th class="px-4 py-2 border-b text-left">Username</th>
+        <th class="px-4 py-2 border-b text-left">Since</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td class="px-4 py-2 border-b"><%= link_to user.username, user_path(user.username) %></td>
+          <td class="px-4 py-2 border-b"><%= user.created_at %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">User: <%= @user.username %></h1>
+  <p>Since: <%= @user.created_at %></p>
+</div>

--- a/app/views/well_known/webfinger/show.html.erb
+++ b/app/views/well_known/webfinger/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">WellKnown::Webfinger#show</h1>
+  <p>Find me in app/views/well_known/webfinger/show.html.erb</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "home/index"
   resource :session
   resources :passwords, param: :token
+  resources :users, only: [ :index, :show ], param: :username
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  scope path: ".well-known" do
+    scope module: :well_known do
+      get "webfinger", to: "webfinger#show", as: :webfinger
+    end
+  end
   get "home/index"
   resource :session
   resources :passwords, param: :token

--- a/db/migrate/20250603180858_add_username_to_users.rb
+++ b/db/migrate/20250603180858_add_username_to_users.rb
@@ -1,0 +1,5 @@
+class AddUsernameToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_23_121007) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_03_180858) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -63,6 +63,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_23_121007) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -2,6 +2,9 @@ require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
+    user = users(:one)
+    post session_url, params: { email_address: user.email_address, password: "password" }
+
     get users_url
     assert_response :success
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get users_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get users_show_url
+    assert_response :success
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -2,12 +2,13 @@ require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get users_index_url
+    get users_url
     assert_response :success
   end
 
   test "should get show" do
-    get users_show_url
+    user = users(:one)
+    get users_url(username: user.username)
     assert_response :success
   end
 end

--- a/test/controllers/well_known/webfinger_controller_test.rb
+++ b/test/controllers/well_known/webfinger_controller_test.rb
@@ -13,7 +13,7 @@ class WellKnown::WebfingerControllerTest < ActionDispatch::IntegrationTest
 
   test "should get 200 OK with valid user" do
     user = users(:one) # Assuming you have a fixture for a valid user
-    get webfinger_url, params: { resource: "acct:#{user.email_address}" }
+    get webfinger_url, params: { resource: "acct:#{user.username}" }
     assert_response :ok
 
     json_response = JSON.parse(response.body)

--- a/test/controllers/well_known/webfinger_controller_test.rb
+++ b/test/controllers/well_known/webfinger_controller_test.rb
@@ -17,7 +17,7 @@ class WellKnown::WebfingerControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
 
     json_response = JSON.parse(response.body)
-    assert_equal "acct:#{user.email_address}", json_response["subject"]
+    assert_equal "acct:#{user.username}", json_response["subject"]
     assert_includes json_response["links"], { "rel" => "self", "type" => "application/activity+json", "href" => root_url }
   end
 end

--- a/test/controllers/well_known/webfinger_controller_test.rb
+++ b/test/controllers/well_known/webfinger_controller_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class WellKnown::WebfingerControllerTest < ActionDispatch::IntegrationTest
+  test "should get 400 Bad Request when no resource provided" do
+    get webfinger_url
+    assert_response :bad_request
+  end
+
+  test "should get 404 Not Found when user does not exist" do
+    get webfinger_url, params: { resource: "acct:test@example.com" }
+    assert_response :not_found
+  end
+
+  test "should get 200 OK with valid user" do
+    user = users(:one) # Assuming you have a fixture for a valid user
+    get webfinger_url, params: { resource: "acct:#{user.email_address}" }
+    assert_response :ok
+
+    json_response = JSON.parse(response.body)
+    assert_equal "acct:#{user.email_address}", json_response["subject"]
+    assert_includes json_response["links"], { "rel" => "http://webfinger.example/rel/profile-page", "href" => "TODO" }
+    assert_includes json_response["links"], { "rel" => "http://webfinger.example/rel/businesscard", "href" => "TODO" }
+  end
+end

--- a/test/controllers/well_known/webfinger_controller_test.rb
+++ b/test/controllers/well_known/webfinger_controller_test.rb
@@ -18,7 +18,6 @@ class WellKnown::WebfingerControllerTest < ActionDispatch::IntegrationTest
 
     json_response = JSON.parse(response.body)
     assert_equal "acct:#{user.email_address}", json_response["subject"]
-    assert_includes json_response["links"], { "rel" => "http://webfinger.example/rel/profile-page", "href" => "TODO" }
-    assert_includes json_response["links"], { "rel" => "http://webfinger.example/rel/businesscard", "href" => "TODO" }
+    assert_includes json_response["links"], { "rel" => "self", "type" => "application/activity+json", "href" => root_url }
   end
 end

--- a/test/controllers/well_known/webfinger_controller_test.rb
+++ b/test/controllers/well_known/webfinger_controller_test.rb
@@ -18,6 +18,6 @@ class WellKnown::WebfingerControllerTest < ActionDispatch::IntegrationTest
 
     json_response = JSON.parse(response.body)
     assert_equal "acct:#{user.username}", json_response["subject"]
-    assert_includes json_response["links"], { "rel" => "self", "type" => "application/activity+json", "href" => root_url }
+    assert_includes json_response["links"], { "rel" => "self", "type" => "application/activity+json", "href" => user_url(user.username) }
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,9 +1,11 @@
 <% password_digest = BCrypt::Password.create("password") %>
 
 one:
+  username: one
   email_address: one@example.com
   password_digest: <%= password_digest %>
 
 two:
+  username: two
   email_address: two@example.com
   password_digest: <%= password_digest %>


### PR DESCRIPTION
As a first step to getting ActivityPub working, lets add basic [Webfinger](https://datatracker.ietf.org/doc/html/rfc7033) support.
This will only support users/authors for the blog, no system entities or anything

**Requirements:**

- [x] `/.well-known/webfinger` Endpoint ([json-ld](https://json-ld.org/))
- [x] Username Identifier (don't use email address)
- [x] Basic profile page for user